### PR TITLE
Add mach tfjson as a command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -88,6 +88,7 @@ Here is a sample Machfile configured with Roll, Terraform and some useful AWS ta
 From the command-line
 
 ```
+mach tfjson
 mach plan
 mach apply
 ```


### PR DESCRIPTION
When running `mach plan` without having run `mach tfjson`, `mach` reports
```
12:41 $ mach plan
Could not resolve target: plan
```